### PR TITLE
adapt for novel np and nibabel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Virtual epileptic patient atlas 
+## (small changes to make it compatible with numpy 1.26 and nibabel above 3.0)
 
 This repository contains the code to reconstruct the virtual epileptic patient (VEP) atlas on a given subjects T1 image. 
 The T1 image is processed with Freesufers recon-all pipeline. 
@@ -10,9 +11,8 @@ An overview of the atlas and the labelling can be found in
 * Freesurfer 
 	* Download available here https://surfer.nmr.mgh.harvard.edu/fswiki/DownloadAndInstall
 * Python with numpy, nibabel and sklearn 
-	* If you have conda installed you can use the following command with the provided environment.yml to create a new python environment with the necessary packages.
-	* conda env create -f environment.yml
-	
+	you can install all dependen using 
+	`pip install -r requirements.txt` in the right python environment
 
 
 ## Run 

--- a/convert_to_vep_parc.py
+++ b/convert_to_vep_parc.py
@@ -189,7 +189,12 @@ def op_split(labels, mode, geom, label_in, labels_out, method, factors=None):
     for label_out, xfr, xto in zip(reversed(labels_out), limits[:-1], limits[1:]):
         imask = (xcoords >= xfr) * (xcoords < xto)
         mask = [idxs[imask] for idxs in indsl]
-        labels[mask] = label_out
+        # labels[mask] = label_out # did change the whole slice. 
+        
+        if len(labels.shape)==1:
+            labels[mask] = label_out
+        else:
+            labels[mask[0],mask[1],mask[2]] = label_out
 
 
 def op_splitto(labels, mode, geom, label_in, labels_out, method):
@@ -256,7 +261,10 @@ def op_splitto(labels, mode, geom, label_in, labels_out, method):
     for lab, x_fr, x_to in zip(labels_out, limits[:-1], limits[1:]):
         imask = (xcoords >= x_fr) * (xcoords < x_to)
         mask = [idxs[imask] for idxs in indsl]
-        labels[mask] = lab
+        if len(labels.shape)==1:
+            labels[mask] = lab
+        else:
+            labels[mask[0],mask[1],mask[2]] = lab
 
 
 def op_splitmes(labels, hemi, verts, triangs, label_in, labels_out):
@@ -343,7 +351,8 @@ def convert_parc(destrieux_annot_file, pial_file, inflated_file, hemisphere, par
 
 def convert_seg(orig_label_file, lut_file, rules_file, vep_label_file):
     mgz_orig = nib.load(orig_label_file)
-    labelvol = mgz_orig.get_data().copy()
+    labelvol = mgz_orig.get_fdata().astype(int).copy()
+    
     affine = mgz_orig.affine
     colorlut = ColorLut(lut_file)
 
@@ -378,7 +387,7 @@ def convert_seg(orig_label_file, lut_file, rules_file, vep_label_file):
             raise ValueError("Unknown rule %s" % rule[0])
 
     assert np.sum(labelvol < 0) == 0
-
+    
     mgz_vep = nib.freesurfer.mghformat.MGHImage(labelvol, affine, mgz_orig.header)
     nib.save(mgz_vep, vep_label_file)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+nibabel==5.3.2
+nilearn==0.11.1
+numpy==2.2.2
+pandas==2.2.3
+scikit_learn==1.4.2


### PR DESCRIPTION
Made VEP atlas compatible with more recent numpy ('5.2.1') and nibabel version abvove 3.0. 
I also added a pip install for a more minimal embedding in existing environments. In this case the environment.yml is not needed. However, I have only tested the basic ability 'create_vep_parc.sh' and did not go into additional functionality. 
